### PR TITLE
채팅과 대댓글 기능 추가

### DIFF
--- a/uniculture/src/main/java/com/capstone/uniculture/controller/ChatRoomController.java
+++ b/uniculture/src/main/java/com/capstone/uniculture/controller/ChatRoomController.java
@@ -35,15 +35,16 @@ public class ChatRoomController {
    * @Request : CreateChatRoomDto (채팅방의 이름과 참여자 명단이 들어감. 추후 단톡방 구현을 위해)
    * @Response : ChatRoomIdResponseDto (새로 생선된 채팅방의 ID가 들어감)
    */
-  @PostMapping("/multi")
+  @PostMapping
   public ResponseEntity<ChatRoomIdResponseDto> createRoom(@RequestBody CreateChatRoomDTO createChatRoomDTO) {
-    return ResponseEntity.ok(chatRoomService.createChatRoomWithMember(createChatRoomDTO));
+    Long memberId = SecurityUtil.getCurrentMemberId();
+    return ResponseEntity.ok(chatRoomService.createChatRoomWithMember(memberId,createChatRoomDTO.getMemberId()));
   }
 
   @GetMapping("/duo")
   public ResponseEntity<ChatRoomIdResponseDto> createDuoRoom(@RequestParam Long toId){
     Long memberId = SecurityUtil.getCurrentMemberId();
-    return ResponseEntity.ok(chatRoomService.createChatRoomWithMemberDuo(memberId, toId));
+    return ResponseEntity.ok(chatRoomService.checkAndCreate(memberId, toId));
   }
 
   //채팅방 입장하면 나와야할 화면, 채팅방 내용도 같이 가져와야함 (한번에 처리필요)

--- a/uniculture/src/main/java/com/capstone/uniculture/controller/CommentController.java
+++ b/uniculture/src/main/java/com/capstone/uniculture/controller/CommentController.java
@@ -1,5 +1,6 @@
 package com.capstone.uniculture.controller;
 
+import com.capstone.uniculture.config.SecurityUtil;
 import com.capstone.uniculture.dto.Comment.CommentDto;
 import com.capstone.uniculture.dto.Comment.CommentResponseDto;
 import com.capstone.uniculture.service.CommentService;
@@ -22,12 +23,19 @@ public class CommentController {
     private final CommentService commentService;
 
 
-    @Operation(summary = "게시물 별 댓글 조회")
-    @GetMapping("/comment/{postId}")
+    @Operation(summary = "게시물의 댓글 조회")
+    @GetMapping("/comment")
     public ResponseEntity<Page<CommentResponseDto>> viewComment(
-            @PageableDefault(size=10, direction = Sort.Direction.DESC) Pageable pageable,
-            @PathVariable("postId") Long postId){
-        return ResponseEntity.ok(commentService.viewComment(postId, pageable));
+            @PageableDefault(size=10, direction = Sort.Direction.ASC) Pageable pageable,
+            @RequestParam("postId") Long postId){
+        try {
+            Long memberId = SecurityUtil.getCurrentMemberId();
+            System.out.println("memberId = " + memberId);
+            return ResponseEntity.ok(commentService.viewCommentLogin(postId, pageable));
+        }
+        catch (RuntimeException e){
+            return ResponseEntity.ok(commentService.viewCommentLogout(postId, pageable));
+        }
     }
 
     @Operation(summary = "댓글 작성")
@@ -35,6 +43,12 @@ public class CommentController {
     public ResponseEntity createComment(@RequestParam("postId") Long postId,
                                        @RequestBody CommentDto commentDto){
         return ResponseEntity.ok(commentService.createComment(postId, commentDto));
+    }
+
+    @Operation(summary = "게시물의 댓글수 조회")
+    @GetMapping("/auth/comment")
+    public ResponseEntity<Long> countComment(@RequestParam("postId") Long postId){
+        return ResponseEntity.ok(commentService.countComment(postId));
     }
 
     @Operation(summary = "댓글 수정")

--- a/uniculture/src/main/java/com/capstone/uniculture/dto/Comment/CommentDto.java
+++ b/uniculture/src/main/java/com/capstone/uniculture/dto/Comment/CommentDto.java
@@ -11,6 +11,7 @@ import lombok.Setter;
 @NoArgsConstructor
 public class CommentDto {
 
+    private Long parentId;
     private String content;
 
     @Builder

--- a/uniculture/src/main/java/com/capstone/uniculture/dto/Comment/CommentResponseDto.java
+++ b/uniculture/src/main/java/com/capstone/uniculture/dto/Comment/CommentResponseDto.java
@@ -7,34 +7,42 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
-@Getter
+@Getter @Setter
 @NoArgsConstructor
 public class CommentResponseDto {
 
-    private Long commentId;
+    private Long id;
     private String content;
     private LocalDateTime createdDate;
     private LocalDateTime modifiedDate;
     private String commentWriterName;
+    private Boolean isMine = Boolean.FALSE;
+    private Boolean postMine = Boolean.FALSE;
+    private Boolean isDeleted = Boolean.FALSE;
+    private List<CommentResponseDto> children = new ArrayList<>();
 
     @Builder
-    public CommentResponseDto(Long commentId, String content, LocalDateTime createdDate, LocalDateTime modifiedDate, String commentWriterName) {
-        this.commentId = commentId;
+    public CommentResponseDto(Long id, String content, LocalDateTime createdDate, LocalDateTime modifiedDate, String commentWriterName, Boolean isDeleted) {
+        this.id = id;
         this.content = content;
         this.createdDate = createdDate;
         this.modifiedDate = modifiedDate;
         this.commentWriterName = commentWriterName;
+        this.isDeleted = isDeleted;
     }
 
 
     public static CommentResponseDto fromEntity(Comment comment){
         return CommentResponseDto.builder()
-                .commentId(comment.getId())
+                .id(comment.getId())
                 .content(comment.getContent())
                 .createdDate(comment.getCreatedDate())
                 .modifiedDate(comment.getModifiedDate())
                 .commentWriterName(comment.getMember().getNickname())
+                .isDeleted(comment.getIsDeleted())
                 .build();
     }
 }

--- a/uniculture/src/main/java/com/capstone/uniculture/dto/Message/ChatRoomDTO.java
+++ b/uniculture/src/main/java/com/capstone/uniculture/dto/Message/ChatRoomDTO.java
@@ -11,21 +11,11 @@ import java.time.LocalDateTime;
 @Builder
 public class ChatRoomDTO {
   private long id;
-  private String name;
+  // 상대 유저 이름
+  private String username;
   // 가장 최근 메시지
   private String latestMessage;
   // 그 메시지를 보낸시간
   private LocalDateTime latestMessageTime;
-  private int memberCount;
 
-  // ChatRoom -> ChatRoomDTO (Response 시 사용)
-  public static ChatRoomDTO fromEntity(ChatRoom chatRoom){
-    return ChatRoomDTO.builder()
-            .id(chatRoom.getId())
-            .name(chatRoom.getName())
-            .latestMessage(chatRoom.getLatestMessage())
-            .latestMessageTime(chatRoom.getLatestMessageTime())
-            .memberCount(chatRoom.getMemberships().size()) // 조심해야됨 고쳐야됨
-            .build();
-  }
 }

--- a/uniculture/src/main/java/com/capstone/uniculture/dto/Message/CreateChatRoomDTO.java
+++ b/uniculture/src/main/java/com/capstone/uniculture/dto/Message/CreateChatRoomDTO.java
@@ -6,7 +6,5 @@ import java.util.List;
 
 @Data
 public class CreateChatRoomDTO {
-  private String name;
-  private List<Long> memberIds;
-
+  private Long memberId;
 }

--- a/uniculture/src/main/java/com/capstone/uniculture/entity/Message/ChatMessage.java
+++ b/uniculture/src/main/java/com/capstone/uniculture/entity/Message/ChatMessage.java
@@ -24,7 +24,7 @@ public class ChatMessage extends BaseEntity {
   @Enumerated(EnumType.STRING)
   private MessageType type;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "chatRoom_id")
   private ChatRoom chatRoom;
 

--- a/uniculture/src/main/java/com/capstone/uniculture/entity/Message/ChatRoom.java
+++ b/uniculture/src/main/java/com/capstone/uniculture/entity/Message/ChatRoom.java
@@ -13,44 +13,37 @@ import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
-@Entity
-@Getter @Setter
+@Entity @Getter @Setter
 @NoArgsConstructor
 public class ChatRoom extends BaseEntity{
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
-
   private String name;
-
   private String latestMessage;
-
-  // 마지막 메시지 시간이 필요함 -> modifiedDate 로 하면 name 이 바뀔때도 변하므로 안됨
   private LocalDateTime latestMessageTime;
+  // 마지막 메시지 시간이 필요함 -> modifiedDate 로 하면 name 이 바뀔때도 변하므로 안됨
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "owner_id")
-  private Member owner;
+  @JoinColumn(name="member1_id", nullable = false)
+  private Member member1;
 
-  @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL)
-  private List<ChatRoomMembership> memberships = new ArrayList<>();
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name="member2_id", nullable = false)
+  private Member member2;
 
   @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL)
   private List<ChatMessage> messages = new ArrayList<>();
 
-  private ChatRoomType chatRoomType;
 
   public ChatRoom(String name, List<Member> members){
     this.name = uniqueName(name, members);
   }
 
-  @Builder
-  public ChatRoom(Long id, String name, Member owner, ChatRoomType chatRoomType) {
-    this.id = id;
-    this.name = name;
-    this.owner = owner;
-    this.chatRoomType = chatRoomType;
+  public ChatRoom(Member member1, Member member2) {
+    this.member1 = member1;
+    this.member2 = member2;
   }
 
   // 연관관계 편의 메소드
@@ -58,12 +51,6 @@ public class ChatRoom extends BaseEntity{
     messages.add(message);
     setLatestMessage(message.getMessage());
     setLatestMessageTime(message.getCreatedDate()); // 만들어진 시간 활용
-  }
-
-  public void addMember(Member member){
-    ChatRoomMembership membership = new ChatRoomMembership(this, member);
-    this.memberships.add(membership);
-    memberships.add(membership);
   }
 
   // 사용자 편의 메소드

--- a/uniculture/src/main/java/com/capstone/uniculture/entity/Post/Comment.java
+++ b/uniculture/src/main/java/com/capstone/uniculture/entity/Post/Comment.java
@@ -3,43 +3,50 @@ package com.capstone.uniculture.entity.Post;
 import com.capstone.uniculture.entity.BaseEntity;
 import com.capstone.uniculture.entity.Member.Member;
 import jakarta.persistence.*;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
+import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 
-@Entity
-@Data
-@NoArgsConstructor
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity @Getter @Setter
+@DynamicInsert @NoArgsConstructor
 public class Comment extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
+    private String content;
+
+    @ColumnDefault("FALSE")
+    private Boolean isDeleted;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "writer_id", nullable = false)
-    //멤버쪽에서는 댓글을 알필요 없음, 게시물만 알고있으면됨. 따라서 단방향 관계
-    private Member member;
+    @BatchSize(size = 10)
+    private Member member; //멤버쪽에서는 댓글을 알필요 없음, 게시물만 알고있으면됨. 따라서 단방향 관계
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Comment parent; // 대댓글일때의 부모 댓글, 없으면 댓글
+
+    @OneToMany(mappedBy = "parent", orphanRemoval = true)
+    @BatchSize(size = 10)
+    private List<Comment> children = new ArrayList<>(); // 자식 댓글
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
-
-    @Column(nullable = false)
-    private String content;
 
     @Builder
     public Comment(Member member, Post post, String content) {
         this.member = member;
         this.post = post;
         this.content = content;
-    }
-
-    // 연관관계 편의 메소드
-
-    public void setPost(Post post){
-        this.post = post;
-        post.getComments().add(this);
     }
 
 }

--- a/uniculture/src/main/java/com/capstone/uniculture/entity/Post/Post.java
+++ b/uniculture/src/main/java/com/capstone/uniculture/entity/Post/Post.java
@@ -46,8 +46,8 @@ public class Post extends BaseEntity {
     @Column(columnDefinition = "TEXT")
     private String content;
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
-    private List<Comment> comments = new ArrayList<>();
+    /*@OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    private List<Comment> comments = new ArrayList<>();*/
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private List<Photo> photos = new ArrayList<>();

--- a/uniculture/src/main/java/com/capstone/uniculture/repository/ChatRoomMembershipRepository.java
+++ b/uniculture/src/main/java/com/capstone/uniculture/repository/ChatRoomMembershipRepository.java
@@ -3,6 +3,7 @@ package com.capstone.uniculture.repository;
 import com.capstone.uniculture.entity.Member.Member;
 import com.capstone.uniculture.entity.Message.ChatRoom;
 import com.capstone.uniculture.entity.Message.ChatRoomMembership;
+import com.capstone.uniculture.entity.Message.ChatRoomType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -21,17 +22,8 @@ public interface ChatRoomMembershipRepository extends JpaRepository<ChatRoomMemb
 
   Optional<ChatRoomMembership> findByChatRoomAndMember(ChatRoom chatRoom, Member member);
 
-  int countByChatRoom_Id(Long chatRoomId);
 
   // 멤버 아이디와 채팅방 아이디를 주고 존재하는지 확인
   Boolean existsByChatRoom_IdAndMember_Id(Long chatroomId, Long memberId);
 
-  // 둘만 있는 채팅방이 있는지 확인하고 있으면 그 채팅방의 아이디를 반환
-  @Query("SELECT crm1.chatRoom.id " +
-          "FROM ChatRoomMembership crm1 " +
-          "INNER JOIN ChatRoomMembership crm2 ON crm1.chatRoom.id = crm2.chatRoom.id " +
-          "WHERE crm1.member.id = :memberId1 AND crm2.member.id = :memberId2 " +
-          "GROUP BY crm1.chatRoom.id " +
-          "HAVING COUNT(crm1.chatRoom.id) = 1")
-  Optional<Long> findChatRoomsWithTwoMembers(Long memberId1, Long memberId2);
 }

--- a/uniculture/src/main/java/com/capstone/uniculture/repository/ChatRoomRepository.java
+++ b/uniculture/src/main/java/com/capstone/uniculture/repository/ChatRoomRepository.java
@@ -1,9 +1,25 @@
 package com.capstone.uniculture.repository;
 
 import com.capstone.uniculture.entity.Message.ChatRoom;
+import com.capstone.uniculture.entity.Message.ChatRoomType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long > {
+
+
+    @Query("SELECT c.id FROM ChatRoom c WHERE c.member1.id = :member1 AND c.member2.id = :member2")
+    Optional<Long> findByMember1_IdAndMember2_Id(@Param("member1") Long member1, @Param("member2") Long member2);
+
+    @Query("SELECT c FROM ChatRoom c JOIN FETCH c.member2 WHERE c.member1.id = :memberId")
+    List<ChatRoom> findByMember1_Id(@Param("memberId") Long memberId);
+
+    @Query("SELECT c FROM ChatRoom c JOIN FETCH c.member1 WHERE c.member2.id = :memberId")
+    List<ChatRoom> findByMember2_Id(@Param("memberId") Long memberId);
 }

--- a/uniculture/src/main/java/com/capstone/uniculture/repository/CommentRepository.java
+++ b/uniculture/src/main/java/com/capstone/uniculture/repository/CommentRepository.java
@@ -3,6 +3,7 @@ package com.capstone.uniculture.repository;
 import com.capstone.uniculture.entity.Post.Comment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,4 +12,13 @@ public interface CommentRepository extends JpaRepository<Comment,Long> {
 
     @Query("SELECT c FROM Comment c WHERE c.post.id = :postId")
     Page<Comment> findCommentByPostId(@Param("postId") Long postId, Pageable pageable);
+
+
+    @Query("SELECT c FROM Comment c " +
+            "JOIN FETCH c.member " +
+            "WHERE c.post.id = :postId " +
+            "AND c.parent.id IS NULL")
+    Page<Comment> findCommentsByBoardIdOrderByParentIdAscCreatedAtAsc(@Param("postId") Long postId, Pageable pageable);
+
+    Long countCommentByPost_Id(Long postId);
 }

--- a/uniculture/src/main/java/com/capstone/uniculture/repository/PostRepository.java
+++ b/uniculture/src/main/java/com/capstone/uniculture/repository/PostRepository.java
@@ -32,6 +32,9 @@ public interface PostRepository extends JpaRepository<Post,Long>, JpaSpecificati
     @Query("SELECT DISTINCT p FROM Post p LEFT JOIN FETCH p.member WHERE p.id = :postId")
     Optional<Post> findPostWithMemberById(@Param("postId") Long postId);
 
+    @Query("SELECT p FROM Post p JOIN FETCH p.member")
+    List<Post> findAllWithMember();
+
     /**
      * 전체 게시물을 조회하는 메소드 - 메인창에 들어갈 내용
      * 여기서는 Comment 까지 Join 필요X. CommentCount 만 쓸꺼기때문
@@ -75,6 +78,8 @@ public interface PostRepository extends JpaRepository<Post,Long>, JpaSpecificati
     @Query(value = "SELECT p FROM Post p JOIN FETCH p.member WHERE p.member.nickname LIKE %:nickname%")
     Page<Post> findAllByNicknameContaining(@Param("nickname") String nickname, Pageable pageable);
 
+    @Query("SELECT p FROM Post p JOIN FETCH p.member WHERE p.id = :postId")
+    Optional<Post> findPostByIdFetch(@Param("postId") Long postId);
 
     // 문제점 : Fetch Join + Paging, LEFT Outer Join + Fetch Join
     // 문제점 : 동적 쿼리로 바꿔줘야됨.

--- a/uniculture/src/main/java/com/capstone/uniculture/service/ChatRoomService.java
+++ b/uniculture/src/main/java/com/capstone/uniculture/service/ChatRoomService.java
@@ -5,7 +5,6 @@ import com.capstone.uniculture.dto.Message.*;
 import com.capstone.uniculture.entity.Member.Member;
 import com.capstone.uniculture.entity.Message.ChatRoom;
 import com.capstone.uniculture.entity.Message.ChatRoomMembership;
-import com.capstone.uniculture.entity.Message.ChatRoomType;
 import com.capstone.uniculture.repository.ChatRoomMembershipRepository;
 import com.capstone.uniculture.repository.ChatRoomRepository;
 import com.capstone.uniculture.repository.MemberRepository;
@@ -14,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -34,48 +34,65 @@ public class ChatRoomService {
               .orElseThrow(()->new IllegalArgumentException("찾는 사용자가 존재하지 않습니다."));
   }
 
-    private ChatRoom findChatRoom(Long roomId) {
-        return chatRoomRepository.findById(roomId)
-                .orElseThrow(() -> new IllegalArgumentException("찾는 채팅방이 존재하지 않습니다"));
-    }
+  // Member 프록시 검색 메소드
+  private Member findMemberReference(Long memberId){
+      return memberRepository.getReferenceById(memberId);
+  }
+
+  // 채팅방 검색 메소드
+  private ChatRoom findChatRoom(Long roomId) {
+      return chatRoomRepository.findById(roomId)
+              .orElseThrow(() -> new IllegalArgumentException("찾는 채팅방이 존재하지 않습니다"));
+  }
 
 
   // 사용자 속한 채팅방만 조회 (기본 채팅방 목록)
-  public List<ChatRoomDTO> findRoomByUserId(Long userId){
+  public List<ChatRoomDTO> findRoomByUserId(Long userId) {
+
+      List<ChatRoomDTO> chatRoomDTOList = new ArrayList<>();
 
       // 1. chatRoomMembershipRepository 에서 유저가 속한 채팅방 검색
-      List<ChatRoomMembership> memberships = chatRoomMembershipRepository.findByMember_Id(userId);
+      List<ChatRoom> chatRoomList = chatRoomRepository.findByMember1_Id(userId);
 
-      // 2. 채팅방 -> DTO 로 변경후 Response
-      return memberships.stream()
-            .map(membership ->
-                    ChatRoomDTO.fromEntity(membership.getChatRoom())
-            )
-            .collect(Collectors.toList());
+      for (ChatRoom chatRoom : chatRoomList) {
+          System.out.println("chatRoom = " + chatRoom.getId());
+          ChatRoomDTO build = ChatRoomDTO.builder().id(chatRoom.getId())
+                  .username(chatRoom.getMember2().getNickname())
+                  .latestMessage(chatRoom.getLatestMessage())
+                  .latestMessageTime(chatRoom.getLatestMessageTime())
+                  .build();
+          chatRoomDTOList.add(build);
+      }
+
+      List<ChatRoom> chatRoomList2 = chatRoomRepository.findByMember2_Id(userId);
+
+      for (ChatRoom chatRoom : chatRoomList2) {
+          System.out.println("chatRoom = " + chatRoom.getId());
+          ChatRoomDTO build = ChatRoomDTO.builder().id(chatRoom.getId())
+                  .username(chatRoom.getMember2().getNickname())
+                  .latestMessage(chatRoom.getLatestMessage())
+                  .latestMessageTime(chatRoom.getLatestMessageTime())
+                  .build();
+          chatRoomDTOList.add(build);
+      }
+
+      return chatRoomDTOList;
   }
 
   // 사용자 담아서 생성
-  public ChatRoomIdResponseDto createChatRoomWithMember(CreateChatRoomDTO createChatRoomDTO) {
+  public ChatRoomIdResponseDto createChatRoomWithMember(Long memberId1, Long memberId2) {
 
-      // 1. JWT 토큰 정보에서 채팅방의 주인 찾기
-      Member owner = findMember(SecurityUtil.getCurrentMemberId());
+      // 1. 생성될 멤버 2명찾기
+      Member member1 = findMemberReference(memberId1);
+      Member member2 = findMemberReference(memberId2);
 
       // 2. 채팅룸 생성
-      ChatRoom chatRoom = ChatRoom.builder()
-              .name(createChatRoomDTO.getName())
-              .owner(owner)
-              .chatRoomType(ChatRoomType.MULTI)
-              .build();
+      ChatRoom chatRoom = new ChatRoom(member1,member2);
 
-      // 3. 채팅룸에 멤버관계 주입
-      createChatRoomDTO.getMemberIds().stream()
-              .map(this::findMember)
-              .forEach(chatRoom::addMember);
-
-      // 4. ID를 뽑아내기전 DB에 저장을 하여 id 자동 생성을 유도함
+      // 3. ID를 뽑아내기전 DB에 저장을 하여 id 자동 생성을 유도함
       chatRoomRepository.save(chatRoom);
 
-      // 5. 만들어진 ID 반환, 이유는 채팅방에 입장했을때 ID 값이 필요하기 때문
+      // 4. 만들어진 ID 반환, 이유는 채팅방에 입장했을때 ID 값이 필요하기 때문
       return new ChatRoomIdResponseDto(chatRoom.getId());
   }
 
@@ -97,7 +114,17 @@ public class ChatRoomService {
     }
 
 
-    public Object createChatRoomWithMemberDuo(Long memberId, Long toId) {
+    public ChatRoomIdResponseDto checkAndCreate(Long memberId1, Long memberId2) {
 
+      // 1. 한쪽 존재확인
+      Optional<Long> exist = chatRoomRepository.findByMember1_IdAndMember2_Id(memberId1, memberId2);
+      if(exist.isPresent()) return new ChatRoomIdResponseDto(exist.get());
+
+      // 2. 반대쪽 존재확인
+      Optional<Long> exist2 = chatRoomRepository.findByMember1_IdAndMember2_Id(memberId2, memberId1);
+      if(exist2.isPresent()) return new ChatRoomIdResponseDto(exist2.get());
+
+      // 3. 여기까지 온거면 둘 사이의 채팅방이 없다는 거니깐 만들어주자
+      return createChatRoomWithMember(memberId1, memberId2);
     }
 }

--- a/uniculture/src/main/java/com/capstone/uniculture/service/ChatService.java
+++ b/uniculture/src/main/java/com/capstone/uniculture/service/ChatService.java
@@ -57,7 +57,6 @@ public class ChatService {
     Member member = findMember(senderId);
     ChatRoom chatRoom = findChatRoom(roomId);
 
-    chatRoom.addMember(member);
 
     ChatMessage chatMessage = ChatMessage.builder()
             .type(MessageType.ENTER)


### PR DESCRIPTION
1. 채팅방 추가 (채팅은 1:1로만 이루어질수 있습니다)
2. 유저간의 채팅방이 이미 존재하는지 확인 (상대 프로필에서 채팅하기 버튼을 눌렀을 때 새로운 채팅방을 생성할지, 아니면 이미 존재하는 채팅방으로 연결할지를 확인하는 용도)
3. 대댓글 기능 추가 (삭제시 대댓글이 있으면 바로 삭제되지않게 설정하였습니다)
4. 이제 Post<->Comment의 관계는 단방향으로 정의됩니다.