### PR TITLE
DB 스키마 조정, 기본값 이슈 해결

### DIFF
--- a/uniculture/src/main/java/com/capstone/uniculture/entity/Member/Member.java
+++ b/uniculture/src/main/java/com/capstone/uniculture/entity/Member/Member.java
@@ -10,19 +10,18 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 
 import java.time.LocalDate;
 import java.util.*;
 import java.util.stream.Collectors;
 
 @Entity
-@Getter
-@Setter
+@Getter @Setter
 @Table(name = "member")
-@NoArgsConstructor
-@AllArgsConstructor
+@NoArgsConstructor @AllArgsConstructor
 @Builder
-@BatchSize(size = 10)
+@DynamicInsert @BatchSize(size = 10)
 public class Member extends BaseEntity {
 
     @Id

--- a/uniculture/src/main/java/com/capstone/uniculture/entity/Message/ChatMessage.java
+++ b/uniculture/src/main/java/com/capstone/uniculture/entity/Message/ChatMessage.java
@@ -7,14 +7,16 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 
 @Entity
-@Getter
-@Setter
+@Getter @Setter
 @NoArgsConstructor
 @Table(indexes = {
         @Index(columnList = "chatRoom_id")
 })
+@DynamicInsert
 public class ChatMessage extends BaseEntity {
 
   @Id
@@ -34,6 +36,9 @@ public class ChatMessage extends BaseEntity {
   private Member member;
 
   private String message;
+
+  @ColumnDefault("false")
+  private Boolean isRead;
 
   @Builder
   public ChatMessage(Long id, MessageType type, ChatRoom chatRoom, Member member, String message) {


### PR DESCRIPTION
1.채팅 메시지에 읽음여부 isRead 추가.
2.DB 스키마의 기본값으로 초기화가 안되는 이슈를 @DynamicInsert로 해결